### PR TITLE
crate education

### DIFF
--- a/prisma/migrations/20250908143825_add_field_university/migration.sql
+++ b/prisma/migrations/20250908143825_add_field_university/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `university` to the `Education` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Education" ADD COLUMN     "university" TEXT NOT NULL;

--- a/prisma/migrations/20250908144328_add_field_start/migration.sql
+++ b/prisma/migrations/20250908144328_add_field_start/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `starDate` on the `Education` table. All the data in the column will be lost.
+  - Added the required column `startDate` to the `Education` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Education" DROP COLUMN "starDate",
+ADD COLUMN     "startDate" TIMESTAMP(3) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -129,9 +129,10 @@ model Profiles {
 
 model Education {
   education_id Int       @id @default(autoincrement())
+  university   String
   degree       String
   fieldOfStudy String
-  starDate     DateTime //ini nanti dibalikan
+  startDate    DateTime //ini nanti dibalikan
   endDate      DateTime?
   description  String?
   Users        Users?    @relation(fields: [user_id], references: [user_id])

--- a/src/controllers/account.controller.ts
+++ b/src/controllers/account.controller.ts
@@ -49,6 +49,38 @@ class AccountController {
   };
   createEducation = async (req: Request, res: Response, next: NextFunction) => {
     try {
+      const { id } = res.locals.decript;
+      await this.accountService.createEducation(req.body, id);
+      sendResponse(res, "success created", 200);
+    } catch (error) {
+      next(error);
+    }
+  };
+  getEducationList = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const id = res.locals.decript.id;
+      const data = await this.accountService.getEducationList(id);
+      sendResponse(res, "success get education list", 200, data);
+    } catch (error) {
+      next(error);
+    }
+  };
+  getEducationDetail = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const education_id = Number(req.params.education_id);
+      if (!education_id) {
+        throw new AppError("incorect req params", 400);
+      }
+      const data = await this.accountService.getDetailEducation(education_id);
+      sendResponse(res, "success get education detail", 200, data);
     } catch (error) {
       next(error);
     }

--- a/src/dto/account.dto.ts
+++ b/src/dto/account.dto.ts
@@ -14,6 +14,6 @@ export interface CreateEducationDTO {
   degree: string;
   fieldOfStudy: string;
   startDate: Date;
-  endDate: Date;
-  description: string | undefined;
+  endDate?: Date;
+  description?: string;
 }

--- a/src/middleware/validation/account.validation.ts
+++ b/src/middleware/validation/account.validation.ts
@@ -8,3 +8,17 @@ export const schemaUpdateProfileRoleUser = z.object({
   birthDate: z.string(), // kirim format "YYYY-MM-DD"
   address: z.string(),
 });
+
+export const schemaCreateEducation = z
+  .object({
+    university: z.string().min(1, "University is required"),
+    degree: z.string().min(1, "Degree is required"),
+    fieldOfStudy: z.string().min(1, "Field of study is required"),
+    startDate: z.string(),
+    endDate: z.string().nullable(),
+    description: z.string().optional(),
+  })
+  .refine((data) => !data.endDate || data.startDate <= data.endDate, {
+    message: "Start date must be before end date",
+    path: ["endDate"],
+  });

--- a/src/repositories/account.repository.ts
+++ b/src/repositories/account.repository.ts
@@ -46,6 +46,22 @@ class AccountRepository {
       return user;
     });
   };
-  createEducation = async (data: CreateEducationDTO, id: number) => {};
+  createEducation = async (data: CreateEducationDTO, id: number) => {
+    return await prisma.education.create({
+      data: { ...data, user_id: id },
+    });
+  };
+  getEducationList = async (id: number) => {
+    return await prisma.education.findMany({
+      where: { user_id: id },
+      omit: { user_id: true },
+    });
+  };
+  getEducationById = async (education_id: number) => {
+    return await prisma.education.findUnique({
+      where: { education_id },
+      omit: { user_id: true },
+    });
+  };
 }
 export default AccountRepository;

--- a/src/routers/account.router.ts
+++ b/src/routers/account.router.ts
@@ -5,7 +5,10 @@ import { validatorRole } from "../middleware/validatorRole";
 import { Role } from "../../prisma/generated/client";
 import { uploadMemory } from "../middleware/uploader";
 import { validator } from "../middleware/validation/validator";
-import { schemaUpdateProfileRoleUser } from "../middleware/validation/account.validation";
+import {
+  schemaCreateEducation,
+  schemaUpdateProfileRoleUser,
+} from "../middleware/validation/account.validation";
 
 class AccountRouter {
   private route: Router;
@@ -30,6 +33,22 @@ class AccountRouter {
       uploadMemory().single("profile_picture"),
       validator(schemaUpdateProfileRoleUser),
       this.accountController.updateProfileRoleUser
+    );
+    this.route.post(
+      "/education/create",
+      validatorRole(Role.USER),
+      validator(schemaCreateEducation),
+      this.accountController.createEducation
+    );
+    this.route.get(
+      "/education/list",
+      validatorRole(Role.USER),
+      this.accountController.getEducationList
+    );
+    this.route.get(
+      "/education/detail/:education_id",
+      validatorRole(Role.USER),
+      this.accountController.getEducationDetail
     );
   }
 

--- a/src/services/account.service.ts
+++ b/src/services/account.service.ts
@@ -1,3 +1,4 @@
+import { id } from "zod/v4/locales/index.cjs";
 import {
   CreateEducationDTO,
   UpdateProfileRoleUserDto,
@@ -25,7 +26,27 @@ class AccountService {
     }
     return result;
   };
-  createEducation = async (data: CreateEducationDTO) => {};
+  createEducation = async (data: CreateEducationDTO, id: number) => {
+    const result = await this.accountRepository.createEducation(data, id);
+    if (!result) {
+      throw new AppError("faild create", 500);
+    }
+    return result;
+  };
+  getEducationList = async (id: number) => {
+    const result = await this.accountRepository.getEducationList(id);
+    if (!result) {
+      throw new AppError("faild get education list", 500);
+    }
+    return result;
+  };
+  getDetailEducation = async (education_id: number) => {
+    const result = await this.accountRepository.getEducationById(education_id);
+    if (!result) {
+      throw new AppError("data not found", 400);
+    }
+    return result;
+  };
 }
 
 export default AccountService;


### PR DESCRIPTION
This pull request introduces a new "Education" feature, allowing users to add, view, and retrieve details about their educational background. It updates the database schema, adds validation, and implements new API endpoints and supporting logic for managing education records.

**Database schema updates:**

* Added a required `university` field and replaced the `starDate` field with `startDate` in the `Education` table. (`prisma/migrations/20250908143825_add_field_university/migration.sql`, `prisma/migrations/20250908144328_add_field_start/migration.sql`, `prisma/schema.prisma`) [[1]](diffhunk://#diff-c240f33ad70663a8cb8ddfd48064b1f627dd7b1f8088b1de027afa9dadfb0238R1-R8) [[2]](diffhunk://#diff-bf1abe9f4d00afe148c0f5aeb4fa4c055ed1bc60e52433f03c8a91a3b4a0d0f9R1-R10) [[3]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR132-R135)

**API and service logic for education records:**

* Implemented new endpoints in `AccountController` and `AccountRouter` for creating an education record, listing all education records for a user, and retrieving details for a specific education record. (`src/controllers/account.controller.ts`, `src/routers/account.router.ts`) [[1]](diffhunk://#diff-2cba80d489d411f2e3a56815559a8aed6a567d79d750b81fc2b205913bc08db0R52-R83) [[2]](diffhunk://#diff-6af4fa0839ec241b3e3a7751a244c818687aa26312ab6b8cc161750674d53b16R37-R52)
* Added corresponding service and repository methods to handle business logic and database interactions for education records. (`src/services/account.service.ts`, `src/repositories/account.repository.ts`) [[1]](diffhunk://#diff-ae339f4b9c9088abe5778710c52cc2247fd78b32b6b142241b7016724d05dc2aL28-R49) [[2]](diffhunk://#diff-656adb74635841ffe93882ae2c86daef5fdc34fa207c6d326b00dce9c1304a61L49-R65)

**Validation improvements:**

* Introduced `schemaCreateEducation` using Zod to validate education data, ensuring required fields are present and that `startDate` is before `endDate`. (`src/middleware/validation/account.validation.ts`, `src/routers/account.router.ts`) [[1]](diffhunk://#diff-7d24acb1013e376787e9abcb4fcba62b8c2d64ff1f550c7f6a79500f6a656997R11-R24) [[2]](diffhunk://#diff-6af4fa0839ec241b3e3a7751a244c818687aa26312ab6b8cc161750674d53b16L8-R11)

**DTO adjustments:**

* Updated `CreateEducationDTO` to make `endDate` and `description` optional, aligning with the new schema and API requirements. (`src/dto/account.dto.ts`)