### PR TITLE
add column deletedAt in skillAssessment table

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -287,6 +287,7 @@ model SkillAssessments {
   skill_name    String
   createAt      DateTime @default(now())
   updatedAt     DateTime @updatedAt
+  deletedAt     DateTime?
 
   assessment_questions AssessmentQuestions[]
   user_assessments     UserAssessments[]


### PR DESCRIPTION
This pull request introduces a soft deletion mechanism to the `SkillAssessments` model by adding a `deletedAt` field. This allows records to be marked as deleted without being permanently removed from the database.

Data model update:

* Added an optional `deletedAt` field of type `DateTime` to the `SkillAssessments` model in `prisma/schema.prisma` to support soft deletion.