### PR TITLE
update migrations

### DIFF
--- a/prisma/migrations/20250910113248_edit_kolom_skill_assessments/migration.sql
+++ b/prisma/migrations/20250910113248_edit_kolom_skill_assessments/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."SkillAssessments" ADD COLUMN     "deletedAt" TIMESTAMP(3);


### PR DESCRIPTION
This pull request introduces a schema update to the `SkillAssessments` table to support soft deletion functionality.

Database schema update:

* Added a nullable `deletedAt` timestamp column to the `SkillAssessments` table to enable soft deletion of records.