### PR TITLE
add tabel

### DIFF
--- a/prisma/migrations/20250911133605_add_user_selection/migration.sql
+++ b/prisma/migrations/20250911133605_add_user_selection/migration.sql
@@ -1,0 +1,34 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `result` on the `Selections` table. All the data in the column will be lost.
+  - You are about to drop the column `user_id` on the `Selections` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."Selections" DROP CONSTRAINT "Selections_user_id_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."SelectionQuestions" ALTER COLUMN "question" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "public"."Selections" DROP COLUMN "result",
+DROP COLUMN "user_id";
+
+-- CreateTable
+CREATE TABLE "public"."UserSelection" (
+    "user_selection_id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "selection_id" INTEGER NOT NULL,
+    "score" DOUBLE PRECISION,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "UserSelection_pkey" PRIMARY KEY ("user_selection_id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."UserSelection" ADD CONSTRAINT "UserSelection_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."Users"("user_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."UserSelection" ADD CONSTRAINT "UserSelection_selection_id_fkey" FOREIGN KEY ("selection_id") REFERENCES "public"."Selections"("selection_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,21 +21,20 @@ model Selections {
   selection_id Int       @id @default(autoincrement())
   job_id       Int       @unique
   passingScore Int
-  result       String?   @db.VarChar
   createAt     DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
   deletedAt    DateTime?
 
+  // Relasi
   job                 Jobs                 @relation(fields: [job_id], references: [job_id])
   selection_questions SelectionQuestions[]
-  user                Users?               @relation(fields: [user_id], references: [user_id])
-  user_id             Int?
+  userSelections      UserSelection[]
 }
 
 model SelectionQuestions {
   selection_question_id Int               @id @default(autoincrement())
   selection_id          Int
-  question              String            @db.VarChar
+  question              String
   option_A              String            @db.VarChar
   option_B              String            @db.VarChar
   option_C              String            @db.VarChar
@@ -44,6 +43,20 @@ model SelectionQuestions {
   createAt              DateTime          @default(now())
   updatedAt             DateTime          @updatedAt
 
+  // Relasi
+  selection Selections @relation(fields: [selection_id], references: [selection_id])
+}
+
+model UserSelection {
+  user_selection_id Int       @id @default(autoincrement())
+  user_id           Int
+  selection_id      Int
+  score             Float? // nullable kalau belum selesai
+  startedAt         DateTime  @default(now())
+  completedAt       DateTime?
+
+  // Relasi
+  user      Users      @relation(fields: [user_id], references: [user_id])
   selection Selections @relation(fields: [selection_id], references: [selection_id])
 }
 
@@ -89,7 +102,7 @@ model Users {
   user_subcription UserSubscriptions[]
   user_assessment  UserAssessments[]
   user_Company     UserCompanies[]
-  selection        Selections[]
+  user_selection   UserSelection[]
   blogs            Blog[]
 }
 

--- a/src/repositories/preselection.repository.ts
+++ b/src/repositories/preselection.repository.ts
@@ -37,11 +37,21 @@ class PreselectionTestRepository {
   getSelectionId = async (job_id: number) => {
     return await prisma.selections.findUnique({
       where: { job_id },
+      include: { selection_questions: true },
     });
   };
   getDetailPreselectionTest = async (selection_id: number) => {
     return await prisma.selectionQuestions.findMany({
       where: { selection_id },
+    });
+  };
+  updatePreselectionTest = async (selection_id: number) => {
+    return await prisma.$transaction(async (tx) => {
+      const result = await tx.selectionQuestions.deleteMany({
+        where: {
+          selection_id,
+        },
+      });
     });
   };
 }

--- a/src/routers/preselection.router.ts
+++ b/src/routers/preselection.router.ts
@@ -22,6 +22,10 @@ class PreselectionRouter {
       validator(schemaPreselectionInput),
       this.preselectionController.createPreselectionTest
     );
+    this.route.get(
+      "/detail/:slug",
+      this.preselectionController.getDetailPreselectionTest
+    );
   }
   public getRouter(): Router {
     return this.route;

--- a/src/services/preselection.service.ts
+++ b/src/services/preselection.service.ts
@@ -25,14 +25,8 @@ class PreselectionService {
     if (!selection) {
       throw new AppError("cannot find selection id", 400);
     }
-    const result =
-      await this.preselectionTestRepository.getDetailPreselectionTest(
-        selection.selection_id
-      );
-    if (!result) {
-      throw new AppError("cannot find selection question", 400);
-    }
-    return result;
+
+    return selection;
   };
 }
 


### PR DESCRIPTION
This pull request introduces a significant refactor to how user selections are modeled and managed in the database, along with related changes in the Prisma schema and backend logic. The core change is the normalization of user selection data into a new `UserSelection` table, decoupling user-specific results from the `Selections` table. Additionally, several backend methods and routes are updated to align with this new structure.

**Database and Schema Refactor:**

* Dropped the `result` and `user_id` columns from the `Selections` table, and created a new `UserSelection` table to store user-specific selection results and metadata, including foreign keys to `Users` and `Selections` (`prisma/migrations/20250911133605_add_user_selection/migration.sql`).
* Updated the Prisma schema: removed the `result` and `user_id` fields from the `Selections` model, added the `UserSelection` model, and updated relationships accordingly in `Selections`, `SelectionQuestions`, and `Users` (`prisma/schema.prisma`). [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL24-R37) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR46-R59) [[3]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL92-R105)

**Backend Logic Updates:**

* Modified the `PreselectionTestRepository.getSelectionId` method to include selection questions when fetching a selection by job ID, and added `updatePreselectionTest` to delete all selection questions for a given selection (`src/repositories/preselection.repository.ts`).
* Changed the preselection test detail retrieval in `PreselectionService` to return the full selection object (with questions) instead of just the questions, reflecting the new schema (`src/services/preselection.service.ts`).
* Added a new route to get preselection test details by slug in the `PreselectionRouter` (`src/routers/preselection.router.ts`).