### PR TITLE
crud preselection test

### DIFF
--- a/prisma/migrations/20250911162757_deletaad/migration.sql
+++ b/prisma/migrations/20250911162757_deletaad/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `deletedAt` on the `Selections` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Selections" DROP COLUMN "deletedAt";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,12 +18,11 @@ datasource db {
 
 // START RISAL
 model Selections {
-  selection_id Int       @id @default(autoincrement())
-  job_id       Int       @unique
+  selection_id Int      @id @default(autoincrement())
+  job_id       Int      @unique
   passingScore Int
-  createAt     DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
-  deletedAt    DateTime?
+  createAt     DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
   // Relasi
   job                 Jobs                 @relation(fields: [job_id], references: [job_id])

--- a/src/controllers/preselection.controller.ts
+++ b/src/controllers/preselection.controller.ts
@@ -42,6 +42,41 @@ class PreselectionController {
       next(error);
     }
   };
+  updatePreselectionTest = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const selection_id = Number(req.params.selection_id);
+      if (isNaN(selection_id)) {
+        throw new AppError(
+          "selection id required or selection id not a number",
+          400
+        );
+      }
+      await this.preselectionService.updatePreselectionTest(
+        selection_id,
+        res.locals.data
+      );
+      sendResponse(res, "success update preselection test", 200);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  deactivePreselectionTest = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const slug = req.params.slug;
+      await this.preselectionService.deactivePreselectionTest(slug);
+      sendResponse(res, "success", 200);
+    } catch (error) {
+      console.log(error);
+    }
+  };
 }
 
 export default PreselectionController;

--- a/src/repositories/preselection.repository.ts
+++ b/src/repositories/preselection.repository.ts
@@ -1,9 +1,11 @@
+import slug from "slug";
 import { prisma } from "../config/prisma";
 import { PreselectionInput } from "../middleware/validation/preselection.validation";
 
 class PreselectionTestRepository {
   createPreSelectionTest = async (data: PreselectionInput, slug: string) => {
     const { passingScore, ...question } = data;
+
     return await prisma.$transaction(async (tx) => {
       const job = await tx.jobs.update({
         where: { slug },
@@ -11,6 +13,18 @@ class PreselectionTestRepository {
           preselection_test: true,
         },
       });
+      // cek apakah sudah ada selection sebelumnya
+      const existingSelection = await tx.selections.findFirst({
+        where: { job_id: job.job_id },
+      });
+      if (existingSelection) {
+        await tx.selectionQuestions.deleteMany({
+          where: { selection_id: existingSelection.selection_id },
+        });
+        await tx.selections.delete({
+          where: { selection_id: existingSelection.selection_id },
+        });
+      }
       const result = await tx.selections.create({
         data: { passingScore, job_id: job.job_id },
       });
@@ -25,10 +39,10 @@ class PreselectionTestRepository {
           correct_option: q.correct_option,
         })),
       });
+
       return result;
     });
   };
-
   findJobId = async (slug: string) => {
     return await prisma.jobs.findUnique({
       where: { slug },
@@ -45,13 +59,42 @@ class PreselectionTestRepository {
       where: { selection_id },
     });
   };
-  updatePreselectionTest = async (selection_id: number) => {
+  updatePreselectionTest = async (
+    selection_id: number,
+    data: PreselectionInput
+  ) => {
     return await prisma.$transaction(async (tx) => {
-      const result = await tx.selectionQuestions.deleteMany({
-        where: {
-          selection_id,
+      const { passingScore, ...question } = data;
+      const updatedSelection = await tx.selections.update({
+        where: { selection_id },
+        data: {
+          passingScore,
         },
       });
+      await tx.selectionQuestions.deleteMany({
+        where: { selection_id },
+      });
+      await tx.selectionQuestions.createMany({
+        data: question.questions.map((q) => ({
+          selection_id,
+          question: q.question,
+          option_A: q.option_A,
+          option_B: q.option_B,
+          option_C: q.option_C,
+          option_D: q.option_D,
+          correct_option: q.correct_option,
+        })),
+      });
+
+      return updatedSelection;
+    });
+  };
+  deactivePreselectionTest = async (slug: string) => {
+    return prisma.jobs.update({
+      where: {
+        slug,
+      },
+      data: { preselection_test: false },
     });
   };
 }

--- a/src/routers/company.route.ts
+++ b/src/routers/company.route.ts
@@ -24,7 +24,7 @@ class CompanyRouter {
     this.route.use(verifyToken);
     this.route.use(validatorRole(Role.COMPANY));
     this.route.get(
-      "/get-data-profile",
+      "/get/my-data-profile",
       this.companyController.getCompanyProfile
     );
     this.route.patch(

--- a/src/routers/preselection.router.ts
+++ b/src/routers/preselection.router.ts
@@ -26,6 +26,15 @@ class PreselectionRouter {
       "/detail/:slug",
       this.preselectionController.getDetailPreselectionTest
     );
+    this.route.patch(
+      "/edit/:selection_id",
+      validator(schemaPreselectionInput),
+      this.preselectionController.updatePreselectionTest
+    );
+    this.route.patch(
+      "/deactive/:slug",
+      this.preselectionController.deactivePreselectionTest
+    );
   }
   public getRouter(): Router {
     return this.route;

--- a/src/services/preselection.service.ts
+++ b/src/services/preselection.service.ts
@@ -28,6 +28,30 @@ class PreselectionService {
 
     return selection;
   };
+  updatePreselectionTest = async (
+    selection_id: number,
+    data: PreselectionInput
+  ) => {
+    const result = await this.preselectionTestRepository.updatePreselectionTest(
+      selection_id,
+      data
+    );
+    if (!data) {
+      throw new AppError("faild update preselection test", 500);
+    }
+    return result;
+  };
+  deactivePreselectionTest = async (slug: string) => {
+    if (!slug) {
+      throw new AppError("slug required", 400);
+    }
+    const result =
+      await this.preselectionTestRepository.deactivePreselectionTest(slug);
+    if (!result) {
+      throw new AppError("faild deactive", 500);
+    }
+    return result;
+  };
 }
 
 export default PreselectionService;


### PR DESCRIPTION
This pull request introduces significant improvements to the preselection test feature, focusing on updating and deactivating preselection tests, as well as cleaning up related data and endpoints. The most important changes are grouped below:

### Preselection Test Update and Deactivation Functionality

* Added new endpoints and controller methods to support updating (`/edit/:selection_id`) and deactivating (`/deactive/:slug`) preselection tests in `PreselectionController`, `PreselectionService`, and `PreselectionRouter`. [[1]](diffhunk://#diff-0bec8837e9f92fc3599aa54213b3adb95789662301bd3511087fb3d001ca7c98R45-R79) [[2]](diffhunk://#diff-6db0b1a8ac426fb3e051dd6a78708f8115004f06521b22512eac913bfd66f66eR29-R37) [[3]](diffhunk://#diff-89f659463b0925600c4380eca0dc16d740499088ffbc2831237e6d10af081d89R31-R54)
* Implemented repository logic to update preselection tests, ensuring that previous questions are deleted and replaced with the new set, and to deactivate a preselection test by updating the `preselection_test` flag in the associated job.

### Data Consistency and Cleanup

* Enhanced the preselection test creation process to check for and remove any existing selection and its questions before creating a new one, preventing duplicate or orphaned data. [[1]](diffhunk://#diff-42f21fe4d3aeae3e99de3df6405a5626fbe9f6f6d57a35aa825ea57279583df5R1-R27) [[2]](diffhunk://#diff-42f21fe4d3aeae3e99de3df6405a5626fbe9f6f6d57a35aa825ea57279583df5R42-L31)

### Schema and Database Changes

* Removed the `deletedAt` column from the `Selections` table in both the Prisma schema and the database migration, reflecting that soft-deletion is no longer used for selections. [[1]](diffhunk://#diff-8b3fb3f15ca080c5c00c7d0fdf8ec8b86e67a5e19d983dc96b0b384083bbbab0R1-R8) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL26)

### API Endpoint Naming

* Updated the company profile endpoint from `/get-data-profile` to `/get/my-data-profile` for clarity and consistency.