### PR TITLE
selection

### DIFF
--- a/src/controllers/preselection.controller.ts
+++ b/src/controllers/preselection.controller.ts
@@ -107,6 +107,20 @@ class PreselectionController {
       next(error);
     }
   };
+  checkIfAlreadySubmit = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const user_id = res.locals.decript.id;
+      const job_id = Number(req.params.job_id);
+      await this.preselectionService.checkIfAlreadySubmit(job_id, user_id);
+      sendResponse(res, "success", 200);
+    } catch (error) {
+      next(error);
+    }
+  };
 }
 
 export default PreselectionController;

--- a/src/repositories/preselection.repository.ts
+++ b/src/repositories/preselection.repository.ts
@@ -13,18 +13,6 @@ class PreselectionTestRepository {
           preselection_test: true,
         },
       });
-      // // cek apakah sudah ada selection sebelumnya
-      // const existingSelection = await tx.selections.findFirst({
-      //   where: { job_id: job.job_id },
-      // });
-      // if (existingSelection) {
-      //   await tx.selectionQuestions.deleteMany({
-      //     where: { selection_id: existingSelection.selection_id },
-      //   });
-      //   await tx.selections.delete({
-      //     where: { selection_id: existingSelection.selection_id },
-      //   });
-      // }
       const result = await tx.selections.create({
         data: { passingScore, job_id: job.job_id },
       });
@@ -105,6 +93,16 @@ class PreselectionTestRepository {
   createUserSelection = async (data: SubmitPreselectionTest) => {
     return await prisma.userSelection.create({
       data: { ...data },
+    });
+  };
+  checkIfAlreadySubmit = async (user_id: number, selection_id: number) => {
+    return await prisma.userSelection.findUnique({
+      where: {
+        user_id_selection_id: {
+          user_id,
+          selection_id,
+        },
+      },
     });
   };
 }

--- a/src/routers/preselection.router.ts
+++ b/src/routers/preselection.router.ts
@@ -47,6 +47,11 @@ class PreselectionRouter {
       validatorRole(Role.USER),
       this.preselectionController.submitSoal
     );
+    this.route.get(
+      "/check-if-already-submit/:job_id",
+      validatorRole(Role.USER),
+      this.preselectionController.checkIfAlreadySubmit
+    );
   }
   public getRouter(): Router {
     return this.route;

--- a/src/services/preselection.service.ts
+++ b/src/services/preselection.service.ts
@@ -80,6 +80,20 @@ class PreselectionService {
     }
     return result;
   };
+  checkIfAlreadySubmit = async (job_id: number, user_id: number) => {
+    const selection = await this.preselectionTestRepository.getSelectionId(
+      job_id
+    );
+    if (!selection) throw new AppError("cannot find selection id", 400);
+    const result = await this.preselectionTestRepository.checkIfAlreadySubmit(
+      user_id,
+      selection?.selection_id
+    );
+    if (!result) {
+      throw new AppError("Must Submit Preselection test", 403);
+    }
+    return result;
+  };
 }
 
 export default PreselectionService;


### PR DESCRIPTION
This pull request introduces a new feature that allows the system to check if a user has already submitted a preselection test for a specific job. The changes span the controller, service, repository, and router layers, adding a new endpoint and the necessary business logic to support this functionality.

**New endpoint for checking preselection test submission:**

* Added a new GET route `/check-if-already-submit/:job_id` to `PreselectionRouter`, which allows users to check if they have already submitted a preselection test for a given job.

**Controller and service logic:**

* Implemented the `checkIfAlreadySubmit` method in `PreselectionController` to handle the new route and delegate the logic to the service layer.
* Added the `checkIfAlreadySubmit` method in `PreselectionService` to retrieve the selection for the job and check if the user has already submitted the test, throwing appropriate errors if not.

**Repository support:**

* Implemented the `checkIfAlreadySubmit` method in `PreselectionTestRepository` to query the database for a user's submission for a specific selection.

**Code cleanup:**

* Removed commented-out code related to selection cleanup in `PreselectionTestRepository` for clarity.