### PR TITLE
revamp api get assessment certificate

### DIFF
--- a/src/repositories/AssessmentCertificate.repository.ts
+++ b/src/repositories/AssessmentCertificate.repository.ts
@@ -20,6 +20,11 @@ class AssessmentCertificateRepository {
                                 username: true,
                             }
                         },
+                        assessment: {
+                            select: {
+                                skill_name: true,
+                            }
+                        }
                     }
                 },
             }


### PR DESCRIPTION
This pull request introduces a small change to the `AssessmentCertificateRepository` by including the `skill_name` field from the related `assessment` entity in the select statement. This allows retrieval of the skill name associated with each assessment certificate.