### PR TITLE
change sameSite strict to none

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -45,7 +45,7 @@ class AuthController {
       res.cookie("token", token, {
         httpOnly: true,
         secure: true,
-        sameSite: "strict", // cegah CSRF
+        sameSite: "none", // cegah CSRF
         maxAge: remember
           ? 30 * 24 * 60 * 60 * 1000 // 30 hari
           : 24 * 60 * 60 * 1000, // 1 hari


### PR DESCRIPTION
This pull request makes a small update to the cookie configuration in the authentication controller. The `sameSite` attribute for the authentication token cookie has been changed from `"strict"` to `"none"` to adjust the CSRF protection settings.

- Changed the `sameSite` attribute in the `res.cookie` call from `"strict"` to `"none"` in `auth.controller.ts`, which may affect cross-site cookie behavior and CSRF protection.