### PR TITLE
update certificate router

### DIFF
--- a/src/routers/AssessmentCertificate.router.ts
+++ b/src/routers/AssessmentCertificate.router.ts
@@ -13,9 +13,9 @@ class AssessmentCertificateRouter {
     }
 
     private initializeRoutes(): void {
+        this.router.get("/:id", this.assessmentCertificateController.getAssessmentCertificate);
         this.router.use(verifyToken);
         this.router.post("/", this.assessmentCertificateController.createAssessmentCertificate);
-        this.router.get("/:id", this.assessmentCertificateController.getAssessmentCertificate);
         this.router.get("/getAllCertificate/byUserId", this.assessmentCertificateController.getAllAssessmentCertificateByUserId);
         this.router.get("/getAllCertificate/byUserId/:id", this.assessmentCertificateController.getAllAssessmentCertificateByUserId);
     }


### PR DESCRIPTION
This pull request makes a small change to the route initialization order in the `AssessmentCertificateRouter`. The route for retrieving a certificate by ID (`GET /:id`) is now registered before the authentication middleware (`verifyToken`), allowing unauthenticated access to this endpoint. All other routes remain protected by authentication. 

- Changed the order of route registration in `AssessmentCertificateRouter` so that `GET /:id` is accessible without authentication, while other routes still require a valid token.